### PR TITLE
update bitmap location in linker script

### DIFF
--- a/include/platform/link.h
+++ b/include/platform/link.h
@@ -13,6 +13,9 @@
  * Entries about linker address
  */
 
+extern uint32_t bss_start;
+extern uint32_t bss_end;
+
 extern uint32_t kernel_text_start;
 extern uint32_t kernel_text_end;
 extern uint32_t kernel_data_start;
@@ -39,15 +42,20 @@ extern uint32_t root_stack_end;
 extern uint32_t kip_start;
 extern uint32_t kip_end;
 
+extern uint32_t bitmap_start;
+extern uint32_t bitmap_end;
+extern uint32_t bitmap_bitband_start;
+extern uint32_t bitmap_bitband_end;
+
 #define __BSS 			__attribute__ ((section(".bss")))
 #define __KIP 			__attribute__ ((section(".kip")))
 #define __ISR_VECTOR		__attribute__ ((section(".isr_vector")))
 #define __KTABLE		__attribute__ ((section(".ktable")))
 
 #ifdef CONFIG_BITMAP_BITBAND
-#define __BITMAP		__attribute__ ((section(".bitmap")))
+#define __BITMAP		__attribute__ ((section(".bitmap_bitband")))
 #else
-#define __BITMAP
+#define __BITMAP		__attribute__ ((section(".bitmap")))
 #endif
 
 #define __USER_TEXT		__attribute__ ((section(".user_text")))

--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -62,8 +62,13 @@ static mempool_t memmap[] = {
 		MP_UR | MP_UW | MP_MEMPOOL  | MP_MAP_ALWAYS, MPT_USER_DATA),
 	DECLARE_MEMPOOL  ("MEM0",  &user_bss_end, 0x2001c000,
 		MP_UR | MP_UW | MP_SRAM, MPT_AVAILABLE),
-	DECLARE_MEMPOOL_2("KBITMAP", kernel_ahb,
+#ifdef CONFIG_BITMAP_BITBAND
+	DECLARE_MEMPOOL  ("KBITMAP",  &bitmap_bitband_start, &bitmap_bitband_end,
 		MP_KR | MP_KW | MP_NO_FPAGE, MPT_KERNEL_DATA),
+#else
+	DECLARE_MEMPOOL  ("KBITMAP",  &bitmap_start, &bitmap_end,
+		MP_KR | MP_KW | MP_NO_FPAGE, MPT_KERNEL_DATA),
+#endif
 	DECLARE_MEMPOOL  ("MEM1",   &kernel_ahb_end, 0x10010000,
 		MP_UR | MP_UW | MP_AHB_RAM, MPT_AVAILABLE),
 	DECLARE_MEMPOOL  ("APB1DEV", 0x40000000, 0x40007800,

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -92,7 +92,7 @@ void __l4_start()
 			/* USER DATA (ROM) -> USER DATA (RAM) */
 
 	/* Fill bss with zeroes */
-	init_zero_seg(&kernel_bss_start, &kernel_bss_end);
+	init_zero_seg(&bss_start, &bss_end);
 	init_zero_seg(&kernel_ahb_start, &kernel_ahb_end);
 	init_zero_seg(&user_bss_start, &user_bss_end);
 

--- a/platform/f9.ld
+++ b/platform/f9.ld
@@ -89,11 +89,16 @@ SECTIONS {
 	/* zero initialized data */
 	.bss (NOLOAD) :
 	{
+		bss_start = .;
 		kernel_bss_start = .;
 		*(.bss*)
 		*(.ktable*)		/* Statically allocated kernel table */
 		*(COMMON)
 		kernel_bss_end = .;
+		bitmap_bitband_start = .;
+		*(.bitmap_bitband*)
+		bitmap_bitband_end = .;
+		bss_end = .;
 	} > RamLoc
 
 	.user_data :
@@ -119,7 +124,9 @@ SECTIONS {
 	.data_AHB (NOLOAD) :
 	{
 		kernel_ahb_start = .;
+		bitmap_start = .;
 		*(.bitmap*)
+		bitmap_end = .;
 		kernel_ahb_end = .;
 	} > RamCCM
 }


### PR DESCRIPTION
To fix #10, my idea is to have 2 different bitmap memory section. One supports bit-band, while the other doesn't.
According to CONFIG_BITMAP_BITBAND, macro __BITMAP gives the appropriate attribute,
but this would complicate mempool and the linker script with many different *_start and *_end.
Any comments are appreciated.
