### PR TITLE
To avoid priority escalation for DebugMon exception

### DIFF
--- a/include/platform/cortex_m.h
+++ b/include/platform/cortex_m.h
@@ -93,6 +93,7 @@ inline uint32_t *MSP(void) {
 #define SCB_VTOR                        (volatile uint32_t *) (SCB_BASE + 0x008)                /* Vector Table Offset Register */
 #define SCB_AIRCR                       (volatile uint32_t *) (SCB_BASE + 0x00c)                /* Application Interrupt/Reset Control Register */
 #define SCB_SCR                         (volatile uint32_t *) (SCB_BASE + 0x010)                /* System Control Register */
+#define SCB_SHPR                        (volatile uint8_t *)  (SCB_BASE + 0x018)                /* System Handler Priority Register */
 #define SCB_SHCSR                       (volatile uint32_t *) (SCB_BASE + 0x024)                /* System Handler Control and State Register */
 #define SCB_CFSR                        (volatile uint32_t *) (SCB_BASE + 0x028)                /* Configurable fault status register - Describes Usage, Bus, and Memory faults */
 #define SCB_HFSR                        (volatile uint32_t *) (SCB_BASE + 0x02C)                /* Hard fault status register - Describes hard fault */

--- a/include/platform/irq.h
+++ b/include/platform/irq.h
@@ -17,6 +17,8 @@
  * 2. We always save all registers even if we do not perform context switching.
  */
 
+void irq_init();
+
 static inline void irq_disable()
 {
 	__asm__ __volatile__ ("cpsid i");

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -40,6 +40,7 @@ int main()
 	dbg_layer = DL_KDB;
 #endif
 
+	irq_init();
 	irq_disable();
 
 	sched_init();

--- a/platform/build.mk
+++ b/platform/build.mk
@@ -17,4 +17,5 @@ platform-y = \
 	bitops.o \
 	debug_uart.o \
 	mpu.o \
-	spinlock.o
+	spinlock.o \
+	irq.o

--- a/platform/irq.c
+++ b/platform/irq.c
@@ -1,0 +1,17 @@
+/* Copyright (c) 2013 The F9 Microkernel Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "board.h"
+
+void irq_init()
+{
+	/* Set all 4-bit to pre-emption priority bit */
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
+
+	/* Set default priority */
+	NVIC_SetPriority(SysTick_IRQn, 0x1, 0);
+	NVIC_SetPriority(SVCall_IRQn, 0x1, 0);
+}
+

--- a/platform/stm32f4/nvic.c
+++ b/platform/stm32f4/nvic.c
@@ -46,7 +46,10 @@ void NVIC_SetPriority(IRQn_Type IRQn, uint8_t group_priority,
 	priority = (group_priority << group_shifts) |
 			(sub_priority & (0xf >> sub_shifts));
 
-	NVIC->IP[IRQn] = priority << 0x4;
+	if (IRQn < 0)
+		*(SCB_SHPR + ((uint32_t)(IRQn) & 0xF)-4) = priority << 0x4;
+	else
+		NVIC->IP[IRQn] = priority << 0x4;
 }
 
 void NVIC_intAttached(IRQn_Type IRQn, PFN_ISR handler,


### PR DESCRIPTION
To avoid unnecessary priority escalation for fault, this patch removes cpsid & cpsie from irq_{save, return}
and set handlers' default priority to 1.
