### PR TITLE
fixes issue #31

### DIFF
--- a/include/platform/irq.h
+++ b/include/platform/irq.h
@@ -100,7 +100,7 @@ static inline int irq_number()
 
 #define schedule_in_irq()						\
 	{								\
-		register tcb_t *sel;					\
+		register tcb_t *sel asm ("r1");				\
 		sel = schedule_select();				\
 		if (sel != current)					\
 			context_switch(current, sel);			\


### PR DESCRIPTION
To avoid compiler allocating `register r4` for `(tcb_t *) sel` which corrupts the interrupted context,
`sel` is forced to allocate `register r1` for its use.
