### PR TITLE
Close IRQ in context switch to avoid abnormal sampling result

### DIFF
--- a/include/platform/irq.h
+++ b/include/platform/irq.h
@@ -47,6 +47,7 @@ static inline int irq_number(void)
  * Saves {r4-r11}, msp, psp
  */
 #define irq_save(ctx) \
+	__asm__ __volatile__ ("cpsid i");				\
 	__asm__ __volatile__ ("mov r0, %0"				\
 			: : "r" ((ctx)->regs) : "r0");			\
 	__asm__ __volatile__ ("stm r0, {r4-r11}");			\
@@ -67,6 +68,7 @@ static inline int irq_number(void)
 	__asm__ __volatile__ ("mov r0, %0" : : "r" ((ctx)->regs));	\
 	__asm__ __volatile__ ("ldm r0, {r4-r11}");			\
 	__asm__ __volatile__ ("msr control, r2");			\
+	__asm__ __volatile__ ("cpsie i");
 
 /* Initial context switches to kernel.
  * It simulates interrupt to save corect context on stack.


### PR DESCRIPTION
This abnormal sampling results from context switch processing in PendSV being
preempted by ktimer IRQ which triggers sampling event.

Fixes #40
