### PR TITLE
mk: enable interpretation of backslash escapes

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -2,12 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-AUTOCONF_H := include/autoconf.h
-config_list := $(shell [ -f $(AUTOCONF_H) ] || touch $(AUTOCONF_H) ; \
-	$(CC) $(CPPFLAGS) -E -dM $(AUTOCONF_H) | \
-	grep -o "\#define CONFIG_[A-Za-z0-9_]*" | cut -c9- | sort)
-$(foreach c,$(config_list) $(config_list),$(eval $(c)=y))
-
 MCONF_MSG = mainmenu "F9 Microkernel Configurations"
 define append_mconf_body
 	MCONF_MSG += \n$(1)


### PR DESCRIPTION
The newline character `\n`  in `mk/config.mk`, as follows, is not interpreted in bash,

```
 MCONF_MSG = mainmenu "F9 Microkernel Configurations"
 define append_mconf_body
         MCONF_MSG += \n$(1)
 endef
```
