### PR TITLE
lib: string: add memcpy and memset

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -85,3 +85,30 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ----------------------------------------------------------------------------
+
+F9 Microkernel utilizes parts of MUSL library project
+(http://www.musl-libc.org/) which are freely redistributable under MIT
+License:
+
+Copyright © 2005-2013 Rich Felker
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------------------------------------------------------------------

--- a/include/lib/string.h
+++ b/include/lib/string.h
@@ -1,0 +1,14 @@
+/* Copyright (c) 2013 The F9 Microkernel Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef	LIB_STRING_H_
+#define	LIB_STRING_H_
+
+#include <types.h>
+
+void *memcpy (void *__restrict, const void *__restrict, size_t);
+void *memset (void *, int, size_t);
+
+#endif /* LIB_STRING_H_ */

--- a/kernel/lib/build.mk
+++ b/kernel/lib/build.mk
@@ -2,9 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+lib-str-y += \
+	memcpy.o \
+	memset.o
+
 kernel-lib-y += \
 	queue.o \
 	ktable.o \
 	stdio.o \
 	bsearch.o \
-	sort.o
+	sort.o \
+	$(lib-str-y)

--- a/kernel/lib/memcpy.c
+++ b/kernel/lib/memcpy.c
@@ -1,0 +1,159 @@
+/* Copyright (c) 2005-2013 Rich Felker
+ * Copyright (c) 2013 The F9 Microkernel Project
+ * All rights reserved.
+ * Use of this source code is governed by MIT license that can be found
+ * in the LICENSE file.
+ */
+
+#include <types.h>
+#include <lib/string.h>
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+	unsigned char *d = dest;
+	const unsigned char *s = src;
+
+#ifdef __GNUC__
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LS >>
+#define RS <<
+#else
+#define LS <<
+#define RS >>
+#endif
+
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	uint32_t w, x;
+
+	for (; (uintptr_t)s % 4 && n; n--)
+		*d++ = *s++;
+
+	if ((uintptr_t)d % 4 == 0) {
+		for (; n >= 16; s += 16, d += 16, n -= 16) {
+			*(u32 *)(d + 0) = *(u32 *)(s + 0);
+			*(u32 *)(d + 4) = *(u32 *)(s + 4);
+			*(u32 *)(d + 8) = *(u32 *)(s + 8);
+			*(u32 *)(d + 12) = *(u32 *)(s + 12);
+		}
+		if (n & 8) {
+			*(u32 *)(d + 0) = *(u32 *)(s + 0);
+			*(u32 *)(d + 4) = *(u32 *)(s + 4);
+			d += 8;
+			s += 8;
+		}
+		if (n & 4) {
+			*(u32 *)(d + 0) = *(u32 *)(s + 0);
+			d += 4;
+			s += 4;
+		}
+		if (n & 2) {
+			*d++ = *s++;
+			*d++ = *s++;
+		}
+		if (n & 1) {
+			*d = *s;
+		}
+		return dest;
+	}
+
+	if (n >= 32)
+		switch ((uintptr_t)d % 4) {
+		case 1:
+			w = *(u32 *)s;
+			*d++ = *s++;
+			*d++ = *s++;
+			*d++ = *s++;
+			n -= 3;
+			for (; n >= 17; s += 16, d += 16, n -= 16) {
+				x = *(u32 *)(s + 1);
+				*(u32 *)(d + 0) = (w LS 24) | (x RS 8);
+				w = *(u32 *)(s + 5);
+				*(u32 *)(d + 4) = (x LS 24) | (w RS 8);
+				x = *(u32 *)(s + 9);
+				*(u32 *)(d + 8) = (w LS 24) | (x RS 8);
+				w = *(u32 *)(s + 13);
+				*(u32 *)(d + 12) = (x LS 24) | (w RS 8);
+			}
+			break;
+		case 2:
+			w = *(u32 *)s;
+			*d++ = *s++;
+			*d++ = *s++;
+			n -= 2;
+			for (; n >= 18; s += 16, d += 16, n -= 16) {
+				x = *(u32 *)(s + 2);
+				*(u32 *)(d + 0) = (w LS 16) | (x RS 16);
+				w = *(u32 *)(s + 6);
+				*(u32 *)(d + 4) = (x LS 16) | (w RS 16);
+				x = *(u32 *)(s + 10);
+				*(u32 *)(d + 8) = (w LS 16) | (x RS 16);
+				w = *(u32 *)(s + 14);
+				*(u32 *)(d + 12) = (x LS 16) | (w RS 16);
+			}
+			break;
+		case 3:
+			w = *(u32 *)s;
+			*d++ = *s++;
+			n -= 1;
+			for (; n >= 19; s += 16, d += 16, n -= 16) {
+				x = *(u32 *)(s + 3);
+				*(u32 *)(d + 0) = (w LS 8) | (x RS 24);
+				w = *(u32 *)(s + 7);
+				*(u32 *)(d + 4) = (x LS 8) | (w RS 24);
+				x = *(u32 *)(s + 11);
+				*(u32 *)(d + 8) = (w LS 8) | (x RS 24);
+				w = *(u32 *)(s + 15);
+				*(u32 *)(d + 12) = (x LS 8) | (w RS 24);
+			}
+			break;
+		}
+	if (n & 16) {
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+	}
+	if (n & 8) {
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+	}
+	if (n & 4) {
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+	}
+	if (n & 2) {
+		*d++ = *s++;
+		*d++ = *s++;
+	}
+	if (n & 1) {
+		*d = *s;
+	}
+	return dest;
+#endif
+
+	for (; n; n--)
+		*d++ = *s++;
+
+	return dest;
+}

--- a/kernel/lib/memset.c
+++ b/kernel/lib/memset.c
@@ -1,0 +1,107 @@
+/* Copyright (c) 2005-2013 Rich Felker
+ * Copyright (c) 2013 The F9 Microkernel Project
+ * All rights reserved.
+ * Use of this source code is governed by MIT license that can be found
+ * in the LICENSE file.
+ */
+
+#include <types.h>
+#include <lib/string.h>
+
+void *memset(void *dest, int c, size_t n)
+{
+	unsigned char *s = dest;
+	size_t k;
+#ifdef __GNUC__
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	typedef uint64_t __attribute__((__may_alias__)) u64;
+	u32 c32;
+	u64 c64;
+#endif
+
+	/* Fill head and tail with minimal branching. Each
+	 * conditional ensures that all the subsequently used
+	 * offsets are well-defined and in the dest region.
+	 */
+
+	if (!n)
+		return dest;
+	s[0] = s[n - 1] = c;
+	if (n <= 2)
+		return dest;
+	s[1] = s[n - 2] = c;
+	s[2] = s[n - 3] = c;
+	if (n <= 6)
+		return dest;
+	s[3] = s[n - 4] = c;
+	if (n <= 8)
+		return dest;
+
+	/* Advance pointer to align it at a 4-byte boundary,
+	 * and truncate n to a multiple of 4. The previous code
+	 * already took care of any head/tail that get cut off
+	 * by the alignment.
+	 */
+
+	k = -(uintptr_t)s & 3;
+	s += k;
+	n -= k;
+	n &= -4;
+
+#ifdef __GNUC__
+	c32 = ((u32)-1)/255 * (unsigned char)c;
+	/* In preparation to copy 32 bytes at a time, aligned on
+	 * an 8-byte bounary, fill head/tail up to 28 bytes each.
+	 * As in the initial byte-based head/tail fill, each
+	 * conditional below ensures that the subsequent offsets
+	 * are valid (e.g. !(n<=24) implies n>=28).
+	 */
+
+	*(u32 *)(s + 0) = c32;
+	*(u32 *)(s + n - 4) = c32;
+	if (n <= 8)
+		return dest;
+	*(u32 *)(s + 4) = c32;
+	*(u32 *)(s + 8) = c32;
+	*(u32 *)(s + n - 12) = c32;
+	*(u32 *)(s + n - 8) = c32;
+	if (n <= 24)
+		return dest;
+	*(u32 *)(s + 12) = c32;
+	*(u32 *)(s + 16) = c32;
+	*(u32 *)(s + 20) = c32;
+	*(u32 *)(s + 24) = c32;
+	*(u32 *)(s + n - 28) = c32;
+	*(u32 *)(s + n - 24) = c32;
+	*(u32 *)(s + n - 20) = c32;
+	*(u32 *)(s + n - 16) = c32;
+
+	/* Align to a multiple of 8 so we can fill 64 bits at a time,
+	 * and avoid writing the same bytes twice as much as is
+	 * practical without introducing additional branching.
+	 */
+
+	k = 24 + ((uintptr_t)s & 4);
+	s += k;
+	n -= k;
+
+	/* If this loop is reached, 28 tail bytes have already been
+	 * filled, so any remainder when n drops below 32 can be
+	 * safely ignored.
+	 */
+
+	c64 = c32 | ((u64)c32 << 32);
+	for (; n >= 32; n -= 32, s += 32) {
+		*(u64 *)(s + 0) = c64;
+		*(u64 *)(s + 8) = c64;
+		*(u64 *)(s + 16) = c64;
+		*(u64 *)(s + 24) = c64;
+	}
+#else
+	/* Pure C fallback with no aliasing violations. */
+	for (; n; n--, s++)
+		*s = c;
+#endif
+
+	return dest;
+}


### PR DESCRIPTION
Introduce string utilities from tag v0.9.14
of MUSL libc project(http://www.musl-libc.org/) with the following
modifications,
1. Remove unused ports and functions
2. Tweak for F9 Microkernel environment

Signed-off-by: Viller Hsiao villerhsiao@gmail.com
