### PR TITLE
Avoid unexpected linker messages "Conflicting CPU architectures 13/0"

### DIFF
--- a/mk/loader.mk
+++ b/mk/loader.mk
@@ -14,8 +14,10 @@ KLDFLAGS = \
 	-r \
 	-b binary
 
+cmd_remove_arm_attributes = $(OBJCOPY) -R '.ARM.attributes' $@ $@
 cmd_kernel_to_o = $(LD) -L loader -T $(KERNEL_OBJ_LDS) $(KLDFLAGS) $< -o $@
-cmd_c_to_o_loader = $(CC) $(CFLAGS_INCLUDE_LOADER) -DLOADER $(CFLAGS) -MMD -MF $@.d -c $< -o $@
+cmd_c_to_o_loader = $(CC) $(CFLAGS_INCLUDE_LOADER) -DLOADER $(CFLAGS) -MMD -MF $@.d -c $< -o $@ && \
+		$(cmd_remove_arm_attributes)
 cmd_loader_elf = $(LD) --oformat $(EXEC_FORMAT) $(loader-objs) $(kernel-obj) -o $@ -L loader -T loader.ld $(LIBGCC)
 
 .PHONY: loader


### PR DESCRIPTION
Fixes #61

The root cause of the issue is that the linker is assuming the wrong
defaults for an object which does not have a .ARM.attributes section.

We can remove all ".ARM.attributes " before linking to avoid this noise.
Please reference
http://permalink.gmane.org/gmane.comp.gnu.binutils/54317
