### PR TITLE
Move loader.mk to mk/rules and rmove misleading target.mk file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,5 +92,4 @@ dir-rules := mk/rules
 $(foreach rule, $(shell ls $(dir-rules)), \
 	$(eval include $(dir-rules)/$(rule)))
 
-include mk/target.mk
 include mk/generic.mk

--- a/mk/rules/loader.mk
+++ b/mk/rules/loader.mk
@@ -1,8 +1,10 @@
 # Copyright (c) 2013 The F9 Microkernel Project. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+ifeq "$(CONFIG_LOADER)" "y"
 
 EXEC_FORMAT = elf32-littlearm
+F9_LD_FILE = f9_sram.ld
 
 loader-objs := $(loader-all-y)
 kernel-obj := $(out)/kernel.loader.o
@@ -21,6 +23,7 @@ cmd_c_to_o_loader = $(CC) $(CFLAGS_INCLUDE_LOADER) -DLOADER $(CFLAGS) -MMD -MF $
 cmd_loader_elf = $(LD) --oformat $(EXEC_FORMAT) $(loader-objs) $(kernel-obj) -o $@ -L loader -T loader.ld $(LIBGCC)
 
 .PHONY: loader
+all: loader
 loader: $(out)/loader.bin
 	mv $(out)/loader.bin $(out)/$(PROJECT).bin
 
@@ -38,3 +41,10 @@ $(out)/kernel_strip.elf: $(out)/$(PROJECT).elf
 
 $(out)/%.loader.o: %.c
 	$(call quiet,c_to_o_loader,CC     )
+
+else
+
+F9_LD_FILE = f9_flash.ld
+all: bare
+
+endif


### PR DESCRIPTION
Fix #65
