### PR TITLE
Fix some bugs in ipc_deliver

### DIFF
--- a/kernel/ipc.c
+++ b/kernel/ipc.c
@@ -174,18 +174,31 @@ void sys_ipc(uint32_t *param1)
 
 uint32_t ipc_deliver(void *data)
 {
-	tcb_t *thr = NULL, *from_thr = NULL;
+	tcb_t *thr = NULL, *from_thr = NULL, *to_thr = NULL;
+	l4_thread_t receiver;
 	int i;
 
 	for (i = 1; i < thread_count; ++i) {
 		thr = thread_map[i];
-
-		if (thr->state == T_RECV_BLOCKED && thr->ipc_from != L4_NILTHREAD &&
-		    thr->ipc_from != L4_ANYTHREAD) {
-			from_thr = thread_by_globalid(thr->ipc_from);
-
-			if (from_thr->state == T_SEND_BLOCKED)
-				do_ipc(from_thr, thr);
+		switch (thr->state) {
+		case T_RECV_BLOCKED:
+			if (thr->ipc_from != L4_NILTHREAD &&
+				thr->ipc_from != L4_ANYTHREAD) {
+				from_thr = thread_by_globalid(thr->ipc_from);
+				if (from_thr->state == T_SEND_BLOCKED)
+					do_ipc(from_thr, thr);
+				}
+			break;
+		case T_SEND_BLOCKED:
+			receiver = thr->utcb->intended_receiver;
+			if (receiver != L4_NILTHREAD && receiver != L4_ANYTHREAD) {
+				to_thr = thread_by_globalid(receiver);
+				if (to_thr->state == T_RECV_BLOCKED)
+					do_ipc(thr, to_thr);
+			}
+			break;
+		default:
+			break;
 		}
 	}
 


### PR DESCRIPTION
1. Issue#72
2. Fix typed message is not copied to receiver.
3. Ipc can be issued only when both sender and receiver are in blocked state.
