### PR TITLE
ipc: add basic support for L4_Sleep

### DIFF
--- a/include/l4/ipc.h
+++ b/include/l4/ipc.h
@@ -36,4 +36,19 @@ typedef union {
 	uint32_t raw;
 } ipc_typed_item;
 
+typedef union {
+	uint16_t raw;
+	struct {
+		uint32_t	m : 10;
+		uint32_t	e : 5;
+		uint32_t	a : 1;
+	} period;
+	struct {
+		uint32_t	m : 10;
+		uint32_t	c : 1;
+		uint32_t	e : 4;
+		uint32_t	a : 1;
+	} point;
+} ipc_time_t;
+
 #endif	/* L4_IPC_H_ */

--- a/include/platform/stm32f4/systick.h
+++ b/include/platform/stm32f4/systick.h
@@ -3,7 +3,8 @@
 
 #include <platform/stm32f4/registers.h>
 
-#define SYSTICK_MAXRELOAD (0x00ffffff)
+#define CORE_CLOCK		(0x0a037a00) /* 168MHz */
+#define SYSTICK_MAXRELOAD	(0x00ffffff)
 
 void init_systick(uint32_t tick_reload, uint32_t tick_next_reload);
 void systick_disable(void);


### PR DESCRIPTION
Basic implementation for L4_Sleep by setting thread to INACTIVE and kicking off a ktimer. This requires a way to know the platform clock speed.
f9micro/f9-kernel#76
