### PR TITLE
ipc: do_ipc should not access thread context's stack pointer if not initialized.

### DIFF
--- a/kernel/ipc.c
+++ b/kernel/ipc.c
@@ -92,6 +92,11 @@ static void do_ipc(tcb_t *from, tcb_t *to)
 		/* TODO: StringItem support */
 	}
 
+	if (!to->ctx.sp || !from->ctx.sp) {
+		caller->state = T_RUNNABLE;
+		return;
+	}
+
 	to->utcb->sender = from->t_globalid;
 
 	to->state = T_RUNNABLE;


### PR DESCRIPTION
Fixes f9micro/f9-kernel#82
