### PR TITLE
root_thread adds mapping to hardware device memory

### DIFF
--- a/include/memory.h
+++ b/include/memory.h
@@ -70,6 +70,9 @@ typedef struct {
 
 #define MP_USER_PERM(mpflags) ((mpflags & 0xF0) >> 4)
 
+/* Mapping value for NO FPAGE region */
+#define INVALID_FPAGE_REGION 0xffffffff
+
 typedef enum {
 	MPT_KERNEL_TEXT,
 	MPT_KERNEL_DATA,


### PR DESCRIPTION
You can test hardware access in root thread by following patch.

```
diff --git a/user/root_thread.c b/user/root_thread.c
index 38effc9..0846a48 100644
--- a/user/root_thread.c
+++ b/user/root_thread.c
@@ -9,6 +9,7 @@
 #include <l4/ipc.h>
 #include <types.h>
 #include <user_runtime.h>
+#include <l4io.h>

 extern user_struct user_runtime_start[];
 extern user_struct user_runtime_end[];
@@ -79,6 +80,27 @@ void __USER_TEXT __root_thread(kip_t *kip_ptr, utcb_t *utcb_ptr)
        L4_ThreadId_t myself = {.raw = utcb_ptr->t_globalid};
        char *free_mem = (char *) get_free_base(kip_ptr);

+       /* Test device memory */
+       printf("*0x40000000 = 0x%x\n", *(unsigned int *)0x40000000);
+       printf("*0x40006000 = 0x%x\n", *(unsigned int *)0x40006000);
+
+       printf("*0x40010000 = 0x%x\n", *(unsigned int *)0x40010000);
+       printf("*0x40012000 = 0x%x\n", *(unsigned int *)0x40012000);
+
+       printf("*0x40014000 = 0x%x\n", *(unsigned int *)0x40014000);
+       printf("*0x40014000 = 0x%x\n", *(unsigned int *)0x40014800);
+
+       printf("*0x40020000 = 0x%x\n", *(unsigned int *)0x40020000);
+       printf("*0x40022000 = 0x%x\n", *(unsigned int *)0x40022000);
+
+       printf("*0x40023c00 = 0x%x\n", *(unsigned int *)0x40023c00);
+
+       printf("*0x50000000 = 0x%x\n", *(unsigned int *)0x50000000);
+
+       printf("*0x50060000 = 0x%x\n", *(unsigned int *)0x50060000);
+
+       printf("*0x60000000 = 0x%x\n", *(unsigned int *)0x60000000);
+
        for (user_struct *ptr = user_runtime_start; ptr != user_runtime_end; ++ptr) {
                L4_ThreadId_t tid;
                L4_Word_t stack;
```
