### PR TITLE
root_thread: fix incorrect update of free_mem

### DIFF
--- a/user/root_thread.c
+++ b/user/root_thread.c
@@ -109,9 +109,9 @@ void __USER_TEXT __root_thread(kip_t *kip_ptr, utcb_t *utcb_ptr)
 			} else {
 				L4_Map(tid, (L4_Word_t)free_mem, fpage->size);
 				fpage->base = (L4_Word_t)free_mem;
+				free_mem += fpage->size;
 			}
 
-			free_mem += fpage->size;
 			fpage++;
 		}
 


### PR DESCRIPTION
free_mem should be updated only if base of fpage is not assigned.