### PR TITLE
[minor] Fix build scripts to work on OS X

### DIFF
--- a/external/kconfig/lxdialog/check-lxdialog.sh
+++ b/external/kconfig/lxdialog/check-lxdialog.sh
@@ -7,7 +7,7 @@ ldflags()
 	for ext in so a dylib ; do
 		for lib in ncursesw ncurses curses ; do
 			$cc -print-file-name=lib${lib}.${ext} | grep -q /
-			if [ $? -eq 0 ]; then
+			if [ $? -eq 0 ] || [ -f /usr/lib/lib${lib}.${ext} ]; then
 				echo "-l${lib}"
 				exit
 			fi
@@ -33,7 +33,7 @@ ccflags()
 }
 
 # Temp file, try to clean up after us
-tmp=$(mktemp)
+tmp=$(mktemp tmp.XXXXXXXXXX)
 trap "rm -f $tmp" 0 1 2 3 15
 
 # Check if we can link to ncurses

--- a/mk/rules/symmap.mk
+++ b/mk/rules/symmap.mk
@@ -7,7 +7,7 @@ ifeq "$(CONFIG_SYMMAP)" "y"
 
 
 cmd_elf_to_symmap = $(NM) $< | sort | cut -d' ' -f1,3 | \
-	sed -n "H;/kernel_text_start/h;/end_of_text/{x;p}"| \
+	sed -n "H;/kernel_text_start/h;/end_of_text/{x;p;}"| \
 	awk 'BEGIN { STRCOUNT = 0; COUNT = 0; } \
 	{ \
 		SYM = SYM "{ (void*) (0x"$$1"), "STRCOUNT" },\n"; \

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -19,7 +19,7 @@ BUILDCC = $(HOST_COMPILE)gcc
 # Misc Information
 GIT_HEAD = $(shell git rev-parse HEAD)
 MACH_TYPE = $(shell uname -m)
-BUILD_TIME = $(shell date --iso=seconds)
+BUILD_TIME = $(shell date +%FT%T%z)
 
 CFLAGS_WARN = \
 	-Wall -Werror -Wundef -Wstrict-prototypes -Wno-trigraphs	\


### PR DESCRIPTION
Not tested on Linux or other OSes but shouldn't break anything.

Tested: Host tools built with Apple Clang sucessfully on Yosemite 10.10.4. F9 built with `arm-none-eabi-gcc` 4.9-2015-q2-update (https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q2-update).