### PR TITLE
kconfig/lxdialog: get ncurses CFLAGS with pkg-config and fixed btn color

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get install build-essential
   - sudo add-apt-repository --yes ppa:terry.guo/gcc-arm-embedded
   - sudo apt-get update
-  - sudo apt-get install gcc-arm-none-eabi
+  - sudo apt-get install gcc-arm-none-eabi -y --force-yes
 
 script:
   - cp -f board/$BOARD/defconfig .config

--- a/external/kconfig/lxdialog/check-lxdialog.sh
+++ b/external/kconfig/lxdialog/check-lxdialog.sh
@@ -4,6 +4,8 @@
 # What library to link
 ldflags()
 {
+	pkg-config --libs ncursesw 2>/dev/null && exit
+	pkg-config --libs ncurses 2>/dev/null && exit
 	for ext in so a dylib ; do
 		for lib in ncursesw ncurses curses ; do
 			$cc -print-file-name=lib${lib}.${ext} | grep -q /
@@ -19,12 +21,17 @@ ldflags()
 # Where is ncurses.h?
 ccflags()
 {
-	if [ -f /usr/include/ncurses/ncurses.h ]; then
+	if pkg-config --cflags ncursesw 2>/dev/null; then
+		echo '-DCURSES_LOC="<ncurses.h>" -DNCURSES_WIDECHAR=1'
+	elif pkg-config --cflags ncurses 2>/dev/null; then
+		echo '-DCURSES_LOC="<ncurses.h>"'
+	elif [ -f /usr/include/ncursesw/curses.h ]; then
+		echo '-I/usr/include/ncursesw -DCURSES_LOC="<curses.h>"'
+		echo ' -DNCURSES_WIDECHAR=1'
+	elif [ -f /usr/include/ncurses/ncurses.h ]; then
 		echo '-I/usr/include/ncurses -DCURSES_LOC="<ncurses.h>"'
 	elif [ -f /usr/include/ncurses/curses.h ]; then
-		echo '-I/usr/include/ncurses -DCURSES_LOC="<ncurses/curses.h>"'
-	elif [ -f /usr/include/ncursesw/curses.h ]; then
-		echo '-I/usr/include/ncursesw -DCURSES_LOC="<ncursesw/curses.h>"'
+		echo '-I/usr/include/ncurses -DCURSES_LOC="<curses.h>"'
 	elif [ -f /usr/include/ncurses.h ]; then
 		echo '-DCURSES_LOC="<ncurses.h>"'
 	else


### PR DESCRIPTION
Fixed from vanilla kernel commit: be8af2d54a669

This makes "make menuconfig" also work on systems where ncurses is not
installed in a standard location (such as on NixOS).

This patch changes ldflags() and ccflags() so that it tries pkg-config first,
and only if pkg-config fails does it go back to the fallback/manual checks.

And, adding -DNCURSES_WIDECHAR=1 CFLAGS to prevent ncurses rendering
wrong color on button when changing dialog color by wbkgdset().