### PR TITLE
Remove CFLAGS -fshort-double

### DIFF
--- a/platform/build.mk
+++ b/platform/build.mk
@@ -13,7 +13,7 @@ CFLAGS_CPU = -mlittle-endian -mcpu=cortex-m4
 endif
 CFLAGS_CPU += -mthumb -mthumb-interwork -Xassembler -mimplicit-it=thumb
 CFLAGS_CPU += -mno-sched-prolog -mno-unaligned-access
-CFLAGS_CPU += -Wdouble-promotion -fsingle-precision-constant -fshort-double
+CFLAGS_CPU += -Wdouble-promotion -fsingle-precision-constant
 CFLAGS_CPU += $(CFLAGS_FPU-y)
 
 platform-y = \


### PR DESCRIPTION
According to gcc mailing list [PATCH 1/2] Remove -fshort-double
(https://gcc.gnu.org/ml/gcc-patches/2014-09/msg02464.html)

CFLAGS -fshort-double has been remove from gcc, testing on
aam-none-eabi-gcc version 6.2.0, CFLAGS -fshort-double report error:

    arm-none-eabi-gcc: error: unrecognized command line
    option '-fshort-double'; did you mean '-fshort-enums'?

So, this patch remove -fshort-double from platform/build.mk.
Compile success @ stm32f429.