### PR TITLE
Add user apps Kconfig for settings

### DIFF
--- a/board/discoveryf4/defconfig
+++ b/board/discoveryf4/defconfig
@@ -148,3 +148,20 @@ CONFIG_PANIC_DUMP_STACK=y
 # CONFIG_CRYP_USER_IRQ is not set
 # CONFIG_HASH_RNG_USER_IRQ is not set
 # CONFIG_FPU_USER_IRQ is not set
+
+#
+# User Space
+#
+CONFIG_BUILD_USER_APPS=y
+
+#
+# Apps
+#
+CONFIG_PINGPONG=y
+
+#
+# Test Cases
+#
+# CONFIG_EXTI_INTERRUPT_TEST is not set
+CONFIG_L4_TEST=y
+# CONFIG_LCD_TEST is not set

--- a/board/discoveryf429/defconfig
+++ b/board/discoveryf429/defconfig
@@ -150,6 +150,18 @@ CONFIG_PANIC_DUMP_STACK=y
 # CONFIG_LOADER is not set
 
 #
-# Test Case
+# User Space
+#
+CONFIG_BUILD_USER_APPS=y
+
+#
+# Apps
+#
+CONFIG_PINGPONG=y
+
+#
+# Test Cases
 #
 CONFIG_EXTI_INTERRUPT_TEST=y
+CONFIG_L4_TEST=y
+CONFIG_LCD_TEST=y

--- a/board/stm32p103/defconfig
+++ b/board/stm32p103/defconfig
@@ -112,6 +112,18 @@ CONFIG_PANIC_DUMP_STACK=y
 # CONFIG_LOADER is not set
 
 #
-# Test Case
+# User Space
+#
+CONFIG_BUILD_USER_APPS=y
+
+#
+# Apps
+#
+CONFIG_PINGPONG=y
+
+#
+# Test Cases
 #
 CONFIG_EXTI_INTERRUPT_TEST=y
+CONFIG_L4_TEST=y
+# CONFIG_LCD_TEST is not set

--- a/user/Kconfig
+++ b/user/Kconfig
@@ -1,11 +1,18 @@
-# Copyright (c) 2015 The F9 Microkernel Project. All rights reserved.
+# Copyright (c) 2015-2017 The F9 Microkernel Project. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-menu "Test Case"
-config EXTI_INTERRUPT_TEST
-	bool "EXTI interrupt test case"
+menu "User Space"
+
+config BUILD_USER_APPS
+	bool "Build user applications for F9 microkernel"
 	default n
-	depends on EXTI0_USER_IRQ && EXTI1_USER_IRQ
+	---help---
+		Enable this options to will compile userspace apps
+		into f9-kernel, This may let you unable to use kdb.
+
+source "user/Kconfig.apps"
+
+source "user/Kconfig.tests"
 
 endmenu

--- a/user/Kconfig.apps
+++ b/user/Kconfig.apps
@@ -1,0 +1,12 @@
+# Copyright (c) 2016 The F9 Microkernel Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+menu "Apps"
+	depends on BUILD_USER_APPS
+
+config PINGPONG
+	bool "Pingpong game"
+	default n
+
+endmenu

--- a/user/Kconfig.tests
+++ b/user/Kconfig.tests
@@ -1,0 +1,21 @@
+# Copyright (c) 2016 The F9 Microkernel Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+menu "Test Cases"
+	depends on BUILD_USER_APPS
+
+config EXTI_INTERRUPT_TEST
+	bool "EXTI interrupt test case"
+	default n
+	depends on EXTI0_USER_IRQ && EXTI1_USER_IRQ
+
+config L4_TEST
+	bool "L4 Test Cases"
+	default n
+
+config LCD_TEST
+	bool "LCD Test Cases"
+	default n
+
+endmenu

--- a/user/apps/build.mk
+++ b/user/apps/build.mk
@@ -1,17 +1,27 @@
-# Copyright (c) 2013 The F9 Microkernel Project. All rights reserved.
+# Copyright (c) 2013,2017 The F9 Microkernel Project. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-user-apps-dirs = \
-	l4test \
-	pingpong
+ifdef CONFIG_BUILD_USER_APPS
 
+user-apps-dirs = ""
+
+ifdef CONFIG_L4_TEST
+user-apps-dirs += \
+	l4test
+endif
+
+ifdef CONFIG_PINGPONG
+user-apps-dirs += \
+	pingpong
+endif
 
 ifdef CONFIG_EXTI_INTERRUPT_TEST
 user-apps-dirs += \
 	irq_test
-else
-ifdef CONFIG_BOARD_STM32F429DISCOVERY
+endif
+
+ifdef CONFIG_LCD_TEST
 user-apps-dirs += \
 	lcd_test
 endif


### PR DESCRIPTION
In this moment, build system will build all program in
folder user/apps, but this may cause unexpected effect,
for example, let kdb unusable in UART.

So, we can add a new kconfig file for apps like test cases
or real user program like pingpong, and thus rename menu
title from "Test Case" to "User Space".

And add submenu "Apps" and "Test Cases" for now.

The structure look like this:
- User Space
  - [ ] Compile with user apps
    - Apps
    - Test Cases
