### PR TITLE
kdb: Add MPU dump

### DIFF
--- a/kernel/kdb.c
+++ b/kernel/kdb.c
@@ -23,6 +23,7 @@ extern void kdb_dump_ktable(void);
 extern void kdb_show_ktimer(void);
 extern void kdb_dump_softirq(void);
 extern void kdb_dump_threads(void);
+extern void kdb_dump_mpu(void);
 extern void kdb_dump_mempool(void);
 extern void kdb_dump_as(void);
 extern void kdb_show_sampling(void);
@@ -58,6 +59,12 @@ struct kdb_t kdb_functions[] = {
 		.name = "THREADS",
 		.menuentry = "dump threads",
 		.function = kdb_dump_threads
+	},
+	{
+		.option = 'M',
+		.name = "MPU",
+		.menuentry = "dump MPU status",
+		.function = kdb_dump_mpu
 	},
 	{
 		.option = 'm',

--- a/platform/stm32-common/mpu.c
+++ b/platform/stm32-common/mpu.c
@@ -102,14 +102,15 @@ int mpu_select_lru(as_t *as, uint32_t addr)
 	return 1;
 }
 
-void mpu_dump(void)
+void mpu_dump(int print_title)
 {
 	int i = 0;
 	uint32_t *mpu_rnr = (uint32_t *) MPU_RNR_ADDR;
 	uint32_t *mpu_base = (uint32_t *) MPU_BASE_ADDR;
 	uint32_t *mpu_attr = (uint32_t *) MPU_ATTR_ADDR;
 
-	dbg_printf(DL_EMERG, "-------MPU------\n");
+	if (print_title)
+		dbg_printf(DL_EMERG, "-------MPU------\n");
 	for (i = 0; i < 8; i++) {
 		*mpu_rnr = i;
 		if (*mpu_attr & 0x1) {
@@ -119,6 +120,13 @@ void mpu_dump(void)
 		}
 	}
 }
+
+#ifdef CONFIG_KDB
+void kdb_dump_mpu(void)
+{
+	mpu_dump(0);
+}
+#endif
 
 void __memmanage_handler(void)
 {
@@ -155,7 +163,7 @@ void __memmanage_handler(void)
 			goto ok;
 	}
 
-	mpu_dump();
+	mpu_dump(1);
 	panic("Memory fault mmsr:%p, mmar:%p,\n"
 	      "             current:%t, psp:%p, pc:%p\n",
 	      mmsr, mmar, current->t_globalid, PSP(), PSP()[REG_PC]);


### PR DESCRIPTION
For education reason, we can add MPU dump in kdb
to observe MPU status interactively.

This commit simply make an warp function `kdb_dump_mpu` for `mpu_dump`,
since `mpu_dump` already print the title, I slightly change the parameter
of `mpu_dump` to change this behavior.

The result will look like this:

        ## KDB ##
        commands:
        K: print kernel tables
        e: dump ktimer events
        n: show timer (now)
        s: show softirqs
        t: dump threads
        M: dump MPU status
        m: dump memory pools
        a: dump address spaces
        p: show sampling
        ----------------


	## KDB ##
	-------MPU------
	b:20011800, sz:2**8, attr:1300
	b:20011900, sz:2**8, attr:1300
	b:20011a00, sz:2**8, attr:1300
	b:20010800, sz:2**11, attr:0300
	b:20012400, sz:2**8, attr:1300
	b:2000f800, sz:2**11, attr:0300
	b:20011600, sz:2**8, attr:1300
	b:20010000, sz:2**10, attr:0300
	----------------