### PR TITLE
kdb: Change dump_mempool output format

### DIFF
--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -503,12 +503,13 @@ void kdb_dump_mempool(void)
 	int i = 0;
 
 	dbg_printf(DL_KDB,
-	           "%10s %10s [%8s:%8s] %10s\n",
-	           "NAME", "SIZE", "START", "END", "FLAGS");
+	           "%2s %20s %10s [%8s:%8s] %10s\n",
+	           "ID", "NAME", "SIZE", "START", "END", "FLAGS");
 
 	for (i = 0; i < sizeof(memmap) / sizeof(mempool_t); ++i) {
 		dbg_printf(DL_KDB,
-		           "%10s %10d [%p:%p] %10s\n",
+		           "%2d %20s %10d [%p:%p] %10s\n",
+		           i,
 		           memmap[i].name, (memmap[i].end - memmap[i].start),
 		           memmap[i].start, memmap[i].end,
 		           kdb_mempool_prop(&(memmap[i])));


### PR DESCRIPTION
Minor change for dump_mempool output format,
Add "id" field and align name field size to 20.

Because stm32f429 will define some long name memmory region in
mempool, thus when we dump out mempool from kdb, it will not align:

	## KDB ##
	-------MEMPOOLS------
	NAME       SIZE       [START   :END     ] FLAGS
	KTEXT           16992 [08001000:08005260] r-x --- N
	UTEXT            4864 [20004500:20005800] --- r-x M
	...
	APB2_3DEV        3072 [40015000:40015c00] --- rw- D
	APB2_4DEV        4352 [40016800:40017900] --- rw- D
	CR_PLLSAION_BB       3072 [42470000:42470c00] --- rw- D
	LCD_FRAME_BUFFER_1     655360 [d0000000:d00a0000] --- rw- D
	LCD_FRAME_BUFFER_2     655360 [d00a0000:d0140000] --- rw- D

This patch will add "ID" field, and align name field size to 20:

	## KDB ##
	-------MEMPOOLS------
	ID NAME                 SIZE       [START   :END     ] FLAGS
	 0 KTEXT                     17020 [08001000:0800527c] r-x --- N
	 1 UTEXT                      4864 [20004500:20005800] --- r-x M
	...
	18 APB2_4DEV                  4352 [40016800:40017900] --- rw- D
	19 CR_PLLSAION_BB             3072 [42470000:42470c00] --- rw- D
	20 LCD_FRAME_BUFFER_1       655360 [d0000000:d00a0000] --- rw- D
	21 LCD_FRAME_BUFFER_2       655360 [d00a0000:d0140000] --- rw- D