### PR TITLE
Fix: misconfig FPU in sys_clock_init

### DIFF
--- a/platform/stm32-common/rcc.c
+++ b/platform/stm32-common/rcc.c
@@ -29,7 +29,7 @@ void sys_clock_init(void)
 {
 	volatile uint32_t startup_count, HSE_status;
 
-#if defined(STM32F4X)
+#if defined(STM32F4X) && defined(CONFIG_FPU)
 	/* Enable the FPU */
 	*SCB_CPACR |= (0xf << 20);
 	/* Enable floating point state preservation */


### PR DESCRIPTION
When testing stm32f429i on qemu-gnueclipse, it bump out
"qemu-system-gnuarmeclipse: Attempt to set CP10/11 in SCB->CPACR, but FP is not supported yet."

Found in sys_clock_init only check STM32F4X, then enable FPU and floating point
state preservation.

Adding CONFIG_FPU to prevent misconfig of FPU.